### PR TITLE
SKIP-147 post cache statistics to the message bus

### DIFF
--- a/include/skippyHLS/skippy_uridownloader.h
+++ b/include/skippyHLS/skippy_uridownloader.h
@@ -64,7 +64,7 @@ struct _SkippyUriDownloaderClass
 
 GType skippy_uri_downloader_get_type (void);
 
-SkippyUriDownloader * skippy_uri_downloader_new (SkippyUriDownloaderCallback callback);
+SkippyUriDownloader * skippy_uri_downloader_new (SkippyUriDownloaderCallback callback, GstElement* parent_element);
 SkippyUriDownloaderFetchReturn skippy_uri_downloader_fetch_fragment (SkippyUriDownloader * downloader, SkippyFragment* fragment,
 	const gchar * referer, gboolean compress, gboolean refresh, gboolean allow_cache, GError ** err);
 void skippy_uri_downloader_reset (SkippyUriDownloader *downloader);

--- a/src/skippy_hlsdemux.c
+++ b/src/skippy_hlsdemux.c
@@ -236,7 +236,7 @@ skippy_hls_demux_init (SkippyHLSDemux * demux)
   demux->client = NULL;
   demux->queue = gst_element_factory_make ("queue2", NULL);
   demux->queue_sinkpad = gst_element_get_static_pad (demux->queue, "sink");
-  demux->downloader = skippy_uri_downloader_new (downloader_callback);
+  demux->downloader = skippy_uri_downloader_new (downloader_callback, GST_ELEMENT(demux));
 
   // Add bin elements
   gst_bin_add (GST_BIN (demux), demux->queue);

--- a/src/skippy_uridownloader.c
+++ b/src/skippy_uridownloader.c
@@ -189,9 +189,9 @@ SkippyUriDownloader *
 skippy_uri_downloader_new (SkippyUriDownloaderCallback callback, GstElement* parent_element)
 {
   SkippyUriDownloader* downloader = g_object_new (TYPE_SKIPPY_URI_DOWNLOADER, NULL);
-  downloader->priv->callback = callback;
 
-  // Parent element which will be used to post httpsrc messages to
+  downloader->priv->callback = callback;
+  // We store a reference to a parent element (optional, can be NULL) in order to forward eventual messages from our bus
   downloader->priv->parent_element = parent_element;
 
   return downloader;
@@ -330,8 +330,11 @@ skippy_uri_downloader_bus_handler (GstBus * bus,
                                         message);
 
   } else if (GST_MESSAGE_TYPE (message) == GST_MESSAGE_ELEMENT) {
+
     // Just forward the message to any other handler interested in custom element stuff
-    gst_element_post_message (downloader->priv->parent_element, gst_message_ref(message));
+    if (downloader->priv->parent_element) {
+      gst_element_post_message (downloader->priv->parent_element, gst_message_ref(message));
+    }
   }
   // Drop the message
   gst_message_unref (message);

--- a/src/skippy_uridownloader.c
+++ b/src/skippy_uridownloader.c
@@ -318,10 +318,7 @@ skippy_uri_downloader_bus_handler (GstBus * bus,
     GstMessage * message, gpointer data)
 {
   SkippyUriDownloader *downloader = (SkippyUriDownloader *) (data);
-  const GstStructure *s;
 
-  // Collect custom statistics from hlsdemux
-  s = gst_message_get_structure (message);
   if (GST_MESSAGE_TYPE (message) == GST_MESSAGE_ERROR) {
 
     skippy_uri_downloader_handle_error (downloader,
@@ -331,11 +328,10 @@ skippy_uri_downloader_bus_handler (GstBus * bus,
 
     skippy_uri_downloader_handle_warning (downloader,
                                         message);
-  } else if (s != NULL && gst_structure_has_name (s, "cache-statistics")) {
-      // Forward the message to the parent element's bus
-      if (gst_structure_has_field(s, "cache-hit-num-bytes")) {
-        gst_element_post_message (downloader->priv->parent_element, gst_message_ref(message));
-      }
+
+  } else if (GST_MESSAGE_TYPE (message) == GST_MESSAGE_ELEMENT) {
+    // Just forward the message to any other handler interested in custom element stuff
+    gst_element_post_message (downloader->priv->parent_element, gst_message_ref(message));
   }
   // Drop the message
   gst_message_unref (message);


### PR DESCRIPTION
@milos-pesic-sc  @tchakabam  See #4 
This PR will instead use the message bus to pass caching information to the skippy instance.
URIDownloader still has to forward the message to the main bus because I did not want to remove the custom event handling from the secondary bus. I assume its there for a reason.